### PR TITLE
add link to reference impl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vss-rs
 
-A rust implementation of a VSS server.
+A rust implementation of a VSS server. Based on [LDK's `vss-server` reference implementation](https://github.com/lightningdevkit/vss-server).
 
 ## Usage
 


### PR DESCRIPTION
want to link to this repo for our d1 postmortem, so thought it would be good if this repo links to the java version

idk if "reference implementation" is the correct term?