### PR TITLE
Add delete_object

### DIFF
--- a/migrations/2023-12-06-020636_deletes/down.sql
+++ b/migrations/2023-12-06-020636_deletes/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE vss_db
+    DROP COLUMN deleted;

--- a/migrations/2023-12-06-020636_deletes/up.sql
+++ b/migrations/2023-12-06-020636_deletes/up.sql
@@ -1,0 +1,68 @@
+ALTER TABLE vss_db
+    ADD COLUMN deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- modify upsert_vss_db to set deleted to false
+CREATE OR REPLACE FUNCTION upsert_vss_db(
+    p_store_id TEXT,
+    p_key TEXT,
+    p_value bytea,
+    p_version BIGINT
+) RETURNS VOID AS
+$$
+BEGIN
+
+    WITH new_values (store_id, key, value, version) AS (VALUES (p_store_id, p_key, p_value, p_version))
+    INSERT
+    INTO vss_db
+    (store_id, key, value, version)
+    SELECT new_values.store_id,
+           new_values.key,
+           new_values.value,
+           new_values.version
+    FROM new_values
+             LEFT JOIN vss_db AS existing
+                       ON new_values.store_id = existing.store_id
+                           AND new_values.key = existing.key
+    WHERE CASE
+              WHEN new_values.version >= 4294967295 THEN new_values.version >= COALESCE(existing.version, -1)
+              ELSE new_values.version > COALESCE(existing.version, -1)
+              END
+    ON CONFLICT (store_id, key)
+        DO UPDATE SET value   = excluded.value,
+                      version = excluded.version,
+                      deleted = false;
+
+END;
+$$ LANGUAGE plpgsql;
+
+-- modified upsert_vss_db but to delete
+CREATE OR REPLACE FUNCTION delete_item(
+    p_store_id TEXT,
+    p_key TEXT,
+    p_version BIGINT
+) RETURNS VOID AS
+$$
+BEGIN
+
+    WITH new_values (store_id, key, version) AS (VALUES (p_store_id, p_key, p_version))
+    INSERT
+    INTO vss_db
+        (store_id, key, version)
+    SELECT new_values.store_id,
+           new_values.key,
+           new_values.version
+    FROM new_values
+             LEFT JOIN vss_db AS existing
+                       ON new_values.store_id = existing.store_id
+                           AND new_values.key = existing.key
+    WHERE CASE
+              WHEN new_values.version >= 4294967295 THEN new_values.version >= COALESCE(existing.version, -1)
+              ELSE new_values.version > COALESCE(existing.version, -1)
+              END
+    ON CONFLICT (store_id, key)
+        DO UPDATE SET value   = NULL,
+                      version = excluded.version,
+                      deleted = true;
+
+END;
+$$ LANGUAGE plpgsql;

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,6 +119,8 @@ async fn main() -> anyhow::Result<()> {
         .route("/v2/putObjects", put(put_objects))
         .route("/listKeyVersions", post(list_key_versions))
         .route("/v2/listKeyVersions", post(list_key_versions))
+        .route("/deleteObject", post(delete_object))
+        .route("/v2/deleteObject", post(delete_object))
         .route("/migration", get(migration::migration))
         .fallback(fallback)
         .layer(

--- a/src/models/schema.rs
+++ b/src/models/schema.rs
@@ -8,5 +8,6 @@ diesel::table! {
         version -> Int8,
         created_date -> Timestamp,
         updated_date -> Timestamp,
+        deleted -> Bool,
     }
 }


### PR DESCRIPTION
If a user deletes and the version number is higher, it will set the `deleted` column to `true` and the `value` to `None`. If another `put_objects` is done that adds a value and has a higher version number then that the key will be un-deleted.