### PR TITLE
allow LAN IPs for cors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ const ALLOWED_ORIGINS: [&str; 6] = [
 
 const ALLOWED_SUBDOMAIN: &str = ".mutiny-web.pages.dev";
 const ALLOWED_LOCALHOST: &str = "http://127.0.0.1:";
+const ALLOWED_LAN: &str = "http://192.168.";
 
 const API_VERSION: &str = "v2";
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,7 +1,9 @@
 use crate::auth::verify_token;
 use crate::kv::{KeyValue, KeyValueOld};
 use crate::models::VssItem;
-use crate::{State, ALLOWED_LOCALHOST, ALLOWED_ORIGINS, ALLOWED_SUBDOMAIN, API_VERSION};
+use crate::{
+    State, ALLOWED_LAN, ALLOWED_LOCALHOST, ALLOWED_ORIGINS, ALLOWED_SUBDOMAIN, API_VERSION,
+};
 use axum::headers::authorization::Bearer;
 use axum::headers::{Authorization, Origin};
 use axum::http::StatusCode;
@@ -244,6 +246,7 @@ pub fn valid_origin(origin: &str) -> bool {
     ALLOWED_ORIGINS.contains(&origin)
         || origin.ends_with(ALLOWED_SUBDOMAIN)
         || origin.starts_with(ALLOWED_LOCALHOST)
+        || origin.starts_with(ALLOWED_LAN)
 }
 
 pub fn validate_cors(origin: Option<TypedHeader<Origin>>) -> Result<(), (StatusCode, String)> {


### PR DESCRIPTION
for doing native dev with live reload I need to connect to an ip address that starts with 192.168, rather than a localhost. not sure if this is the right way to do it but \o/

only needed for staging